### PR TITLE
Update references to 2.2

### DIFF
--- a/_baselines/ChangeLog3.md
+++ b/_baselines/ChangeLog3.md
@@ -44,6 +44,7 @@ Note: Minor punctuation, formatting and spelling changes not included.
 | 22. Resize Text | Test instructions: included methods from F94; Techniques: added F94. |
 | 24. Parsing | Removed test instructions; per [WCAG 2.0 Errata](https://www.w3.org/WAI/WCAG20/errata/) Editorial Errata 13, the parsing test always passes. |
 | Appendix A | Added Test Instructions with "check" and linked test instructions, sort function, links to Baselines and Test IDs. |
+| Appendix C - References | Updated links for WCAG to 2.2 |
 | Site home | Added single file of all Baseline Tests. | 
 
 ### Version 3.0.1, March 2021

--- a/_baselines/ChangeLog3.md
+++ b/_baselines/ChangeLog3.md
@@ -43,7 +43,7 @@ Note: Minor punctuation, formatting and spelling changes not included.
 | 20.A Conforming Alternate Version | Test instructions: added check that content indicates that a conforming alternate version is available. |
 | 22. Resize Text | Test instructions: included methods from F94; Techniques: added F94. |
 | 24. Parsing | Removed test instructions; per [WCAG 2.0 Errata](https://www.w3.org/WAI/WCAG20/errata/) Editorial Errata 13, the parsing test always passes. |
-| Appendix A | Added Test Instructions with "check" and linked test instructions, sort function, links to Baselines and Test IDs. |
+| Appendix A – Cross Reference Tables | Added Test Instructions with "check" and linked test instructions, sort function, links to Baselines and Test IDs. |
 | Appendix C - References | Updated links for WCAG to 2.2 |
 | Site home | Added single file of all Baseline Tests. | 
 

--- a/_baselines/references.md
+++ b/_baselines/references.md
@@ -12,7 +12,7 @@ order-number: 102
 
 - [HTML Accessibility API Mappings 1.0](https://w3c.github.io/html-aam/)
 
-- [How to Meet WCAG (Quick Reference)](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa&versions=2.0)
+- [How to Meet WCAG (Quick Reference)](https://www.w3.org/WAI/WCAG22/quickref/?currentsidebar=%23col_customize&versions=2.0&levels=aaa)
 
 - [Understanding WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/)
 

--- a/_baselines/references.md
+++ b/_baselines/references.md
@@ -14,7 +14,7 @@ order-number: 102
 
 - [How to Meet WCAG (Quick Reference)](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa&versions=2.0)
 
-- [Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/)
+- [Understanding WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/)
 
 ### Glossary References
 

--- a/_baselines/references.md
+++ b/_baselines/references.md
@@ -22,4 +22,4 @@ order-number: 102
 
 - [US Access Board Section 508 Defined Terms](https://www.access-board.gov/ict/#E103.4)
 
-- [WCAG 2.0 glossary](https://www.w3.org/TR/WCAG20/#glossary)
+- [WCAG 2.2 glossary](https://www.w3.org/TR/WCAG22/#glossary)


### PR DESCRIPTION
update WCAG Understanding and glossary

closes #450 