### PR TITLE
Spell out ICT on first use

### DIFF
--- a/_baselines/index.md
+++ b/_baselines/index.md
@@ -5,7 +5,7 @@ permalink: /
 ---
 ## Information and Communication Technology (ICT) Testing Baseline for Web Accessibility
 
-This is the Section 508 [Information and Communication Technology](https://www.access-board.gov/ict/#E103.4) (ICT) Testing Baseline ***for Web***, version 3.1 (published April 1, 2024). This Baseline identifies the minimum requirements of any test process used to determine conformance of web content with the [Revised Section 508 of the Rehabilitation Act of 1973](https://www.access-board.gov/ict), as amended (29 U.S.C. 794d).
+This is the Section 508 [Information and Communication Technology](https://www.access-board.gov/ict/#defICT) (ICT) Testing Baseline ***for Web***, version 3.1 (published April 1, 2024). This Baseline identifies the minimum requirements of any test process used to determine conformance of web content with the [Revised Section 508 of the Rehabilitation Act of 1973](https://www.access-board.gov/ict), as amended (29 U.S.C. 794d).
 
 [Previous versions of the Baseline for Web](https://github.com/atbcb/ICTTestingBaseline/releases) are available on the Github repository.
 

--- a/_baselines/index.md
+++ b/_baselines/index.md
@@ -3,9 +3,9 @@ title: "Section 508 ICT Testing Baseline for Web"
 order-number: 0
 permalink: /
 ---
-## ICT Testing Baseline for Web Accessibility
+## Information and Communication Technology (ICT) Testing Baseline for Web Accessibility
 
-This is the Section 508 ICT Testing Baseline ***for Web***, version 3.1 (published April 1, 2024). This Baseline identifies the minimum requirements of any test process used to determine conformance of web content with the [Revised Section 508 of the Rehabilitation Act of 1973](https://www.access-board.gov/ict), as amended (29 U.S.C. 794d).
+This is the Section 508 [Information and Communication Technology](https://www.access-board.gov/ict/#E103.4) (ICT) Testing Baseline ***for Web***, version 3.1 (published April 1, 2024). This Baseline identifies the minimum requirements of any test process used to determine conformance of web content with the [Revised Section 508 of the Rehabilitation Act of 1973](https://www.access-board.gov/ict), as amended (29 U.S.C. 794d).
 
 [Previous versions of the Baseline for Web](https://github.com/atbcb/ICTTestingBaseline/releases) are available on the Github repository.
 


### PR DESCRIPTION
Per recommendation from user, PR to define/spell out ICT on first use on index page.